### PR TITLE
Clarification on Programming Exercise 7.1

### DIFF
--- a/processes.tex
+++ b/processes.tex
@@ -2420,8 +2420,8 @@ On a copy of Figure~\ref{vmm-example} from page~\pageref{vmm-example}, use five 
 Write and test a variant of the {\tt forker} program from Figure~\ref{forker-code}
 on page~\pageref{forker-code},
 in which as much code as possible is shared between the parent and
-child processes. The variant should behave the same as the original 
-{\tt forker} program given the same input.
+child processes. The variant should still produce the same output as the original 
+{\tt forker} program.
 \item\label{dissimilar-processes-project}
 Write a variant of the {\tt forker} program from Figure~\ref{forker-code} on
 page~\pageref{forker-code},


### PR DESCRIPTION
I added the sentence:
"The variant should behave the same as the original 

```
   "The variant should behave the same as the original {\tt forker} program given the same input."
```

to the text of the Programming Project 7.1 to specify that the end-result of the project should share as much code as possible between the parent and child processes while still maintaining the same functionality.
