### PR TITLE
Update scheduling.tex

### DIFF
--- a/scheduling.tex
+++ b/scheduling.tex
@@ -634,12 +634,12 @@ many operating systems attempt to follow.
 
 As an aside about priorities, whether fixed or otherwise, it is
 important to note that some real systems use smaller priority numbers
-to indicate more prefered threads and larger priority numbers to
-indicate those that are less prefered.  Thus, a ``higher priority''
+to indicate more preferred threads and larger priority numbers to
+indicate those that are less preferred.  Thus, a ``higher priority''
 thread  may actually be indicated by a
 lower priority number.
 In this book, I will consistenty use ``higher priority'' and ``lower
-priority'' to mean more and less prefered, independent of how those
+priority'' to mean more and less preferred, independent of how those
 are encoded as numbers by a particular system.
 
 In a fixed-priority scheduler, the run queue can be kept in a


### PR DESCRIPTION
changed the three instances of "prefered" to "preferred" in the beginning of 3.4
