### PR TITLE
Fixes #41

### DIFF
--- a/transactions.tex
+++ b/transactions.tex
@@ -1907,8 +1907,8 @@ so as to test the use of undo logs.
 \section*{Exploration Projects}
 \begin{chapterEnumerate}
 \item
-Work through the examples in Chapter~25 (``Transactions'') of the
-\textit{J2EE 1.4 Tutorial}.
+Work through the examples in Chapter (``Transactions'') of the
+\textit{Java EE Tutorial}. This is Chapter 51 as of Tutorial 7.
 \item
 On a Linux system that uses an ext3fs file system, for which you have
 permission to change mount options, experiment with the performance


### PR DESCRIPTION
Updated reference to J2EE, now refers to Java EE and additionally points to the chapter in the Java EE 7 Tutorial.
