### PR TITLE
Mac has something like vmstat

### DIFF
--- a/threads.tex
+++ b/threads.tex
@@ -910,7 +910,7 @@ time?
 How frequently does a system switch threads?  You can find this out on
 a Linux system by using the \verb|vmstat| program.  Read the
 man page for \verb|vmstat|, and then run it to find the number of context
-switches per second.
+switches per second. (The Mac OS X \verb|vm_stat| program is similar.)
 Write a report in which you carefully
 explain what you did and the hardware and software system context in
 which you did it, so that someone else could replicate your


### PR DESCRIPTION
I don't use this myself so I'm not sure, but it appears that Mac has a `vm_stat` which is analogous to `vmstat`, though the outputs seem quite differently formatted.  (FreeBSD also seems to have `vmstat` so I'm not sure where in the BSD genealogy each of these were introduced.)  Hope you find this a helpful suggestion to add.