### PR TITLE
Kibi

### DIFF
--- a/persistence.tex
+++ b/persistence.tex
@@ -792,10 +792,14 @@ into storage locations.  In virtual memory, the mapping is from
 virtual addresses within address spaces to physical addresses within
 memory.  In a file system, the mapping is from positions within files
 to locations in persistent storage.  For efficiency, the mapping is done at a coarse
-granularity, several kilobytes at a time.  In virtual memory, each
+granularity, several kibibytes at a time.  In virtual memory, each
 page is mapped into a page frame; in a file system, each block of a
-file is mapped into a storage block.  (You will see that blocks are
-typically several kilobytes in size, spanning multiple sectors.)
+file is mapped into a storage block.  (Recall from Section~\ref{vm-reps}
+that ``kibi'' is the binary unit for 1024.  You will see that blocks are
+typically several kibibytes in size, spanning multiple sectors.
+Note, however, that transfer speeds and \emph{sizes} of hard disks are
+usually advertised based on powers of ten.  In particular, a 1-TB disk is
+way too small to store 1 TiB.)
 
 When discussing virtual memory, I remarked that the operating system
 was free to assign any unused page frame of physical memory to hold
@@ -850,9 +854,9 @@ subsection the phenomena that cause space to be unusable.
 
 One source of waste is that space is allocated only in integer
 multiples of some file system block size.  For example, a file system
-might allocate space only in units of 4~KB.  A file that is too big to
-fit in a single 4-KB unit will be allocated 8~KB of space---even if it
-is only a single byte larger than 4~KB.  The unused space in the last
+might allocate space only in units of 4~KiB.  A file that is too big to
+fit in a single 4-KiB unit will be allocated 8~KiB of space---even if it
+is only a single byte larger than 4~KiB.  The unused space in the last
 file block is called \foldvocab{internal}{fragmentation}.  The
 amount of internal fragmentation depends not only on the desired file sizes,
 but also on the file system block size.  As an analogy, consider
@@ -866,7 +870,7 @@ The file system block size is always some multiple of the underlying
 disk drive's sector size; no file system ever subdivides the space
 within a single disk sector.  Generally the file system blocks span
 several consecutive disk sectors; for example, eight disk sectors of 512
-bytes each might be grouped into each 4-KB file system block.  Larger
+bytes each might be grouped into each 4-KiB file system block.  Larger
 file system blocks cause more internal fragmentation, but are
 advantageous from other perspectives.  In particular, you will see that
 a larger block size tends to reduce
@@ -882,9 +886,9 @@ consecutive extent.  For the moment, I will consider this to be an
 absolute requirement.  Later, I will consider relaxing it.
 
 Continuing with my earlier example, suppose you need space for a file
-that is just one byte larger than 4~KB and hence has been rounded up
-to two 4-KB blocks.  The new requirement of contiguity means that you
-are looking for somewhere on the disk where two consecutive 4-KB blocks
+that is just one byte larger than 4~KiB and hence has been rounded up
+to two 4-KiB blocks.  The new requirement of contiguity means that you
+are looking for somewhere on the disk where two consecutive 4-KiB blocks
 are free.  Perhaps you are out of luck.  Maybe the disk is only half
 full, but the half that is full consists of every even-numbered file
 system block with all the odd-numbered ones available for use.  This
@@ -1043,8 +1047,8 @@ which increases internal fragmentation, decreases external
 fragmentation.  The reason for this is that with a larger block size,
 there is less variability in the amount of space being allocated.
 Files that might have different sizes when rounded up to the next
-kilobyte (say, 14~KB and 15~KB) may have the same size when rounded to
-the next multiple of 4~KB (in this case, 16~KB and 16~KB).  Reduced
+kibibyte (say, 14~KiB and 15~KiB) may have the same size when rounded to
+the next multiple of 4~KiB (in this case, 16~KiB and 16~KiB).  Reduced
 variability reduces external fragmentation; in the extreme case, no
 external fragmentation at all occurs if the files are all allocated
 the same amount of space.
@@ -1147,8 +1151,8 @@ search an entire large disk for a desired size extent of free space.
 Many UNIX and Linux file systems use a slight variant on the bitmap
 approach.  Linux's ext3fs file system can serve as an example.  The
 overall disk space is divided into modest-sized chunks known as
-\vocabs{block group}.  On a system with 4-KB disk blocks,
-a block group might encompass 128~MB.  Each block group has its own
+\vocabs{block group}.  On a system with 4-KiB disk blocks,
+a block group might encompass 128~MiB.  Each block group has its own
 bitmap, indicating which blocks within that group are free.  (In
 Exercise~\ref{block-group-bitmap-exercise}, you can show that in the example given, each block group's
 bitmap fits within a single block.)  Summary information for the file
@@ -1391,8 +1395,8 @@ allocate a second inode; it allocates a whole additional disk block, an
 \foldvocab{indirect}{block}.  This provides room for many more
 block numbers, as shown in Figure~\ref{single-indirect-inode}.  The
 exact number of additional block numbers depends on how big blocks and
-block numbers are.  With 4-KB blocks and 4-byte block numbers, an
-indirect block could hold 1~K block numbers (that is, 1024 block
+block numbers are.  With 4-KiB blocks and 4-byte block numbers, an
+indirect block could hold 1~Ki block numbers (that is, 1024 block
 numbers), as shown in the figure.  This kind of indirect block is more
 specifically called a \foldvocab{single}{indirect block}, because it
 adds only a single layer of indirection: the inode points to it, and
@@ -1414,8 +1418,8 @@ appearance in the figure.}
 \label{single-indirect-inode}
 \end{figure}
 
-In this example with 4-KB blocks, the single indirect block allows you
-to accommodate files slightly more than 4~MB in size.  To handle
+In this example with 4-KiB blocks, the single indirect block allows you
+to accommodate files slightly more than 4~MiB in size.  To handle
 yet-larger files, you can use a multilevel tree scheme, analogous to
 multilevel page tables.  The inode can contain a block number for a
 double indirect block, which contains block numbers for many more
@@ -1612,7 +1616,7 @@ each.
 
 At first, it may not be obvious why extent maps are a big improvement.
 A typical block map system might use a 4-byte block number to refer
-to each 4-KB block.  This is less than one-tenth of one percent space
+to each 4-KiB block.  This is less than one-tenth of one percent space
 overhead, surely affordable with today's cheap disk storage.  What
 reason do file system designers have to try to further reduce such an already small
 overhead?  (I will ignore the possibility that the extent map takes
@@ -1641,7 +1645,7 @@ Linux from SGI's IRIX version of UNIX.  For files that have only a
 handful of extents (by far the most common case), all three store the
 sequence of extent map entries in the inode or (in Windows and Mac
 OS~X) in the corresponding inode-like structure.  The analogs of inodes in
-NTFS are large enough (1~KB) that they can directly store entire
+NTFS are large enough (1~KiB) that they can directly store entire
 extent maps for most files, even those with more than a few extents. The other
 two file systems use smaller inodes (or inode-like structures) and so
 provide an interesting comparison of techniques for handling the
@@ -1733,7 +1737,7 @@ The first subtree contains keys smaller than the first root key, the
 next subtree contains keys between the first and second root keys,
 and so forth.  The last subtree contains keys larger than the last root key.
 
-If a multi-kilobyte disk block is used to hold a B-tree node, the
+If a multi-kibibyte disk block is used to hold a B-tree node, the
 value of $N$ can be quite large, resulting in a broad, shallow tree.
 In fact, even if a disk block were only half full with root keys and
 subtree pointers, it would still provide a substantial branching
@@ -2683,7 +2687,7 @@ using indexes.  However, this feature may have other undesirable
 consequences for system performance.  Based on the description in this
 chapter, what would you expect the performance problem to be?
 \item\label{block-group-bitmap-exercise}
-Show that if a file system uses 4-KB disk blocks and 128-MB block
+Show that if a file system uses 4-KiB disk blocks and 128-MiB block
 groups, the bitmap for a block group fits within a single block.
 \item\label{best-fit-first-fit-exercise}
 Best-fit allocation sounds superior to first-fit, but in actuality,
@@ -2698,7 +2702,7 @@ other in which first-fit succeeds but best-fit gets stuck.
 \item\label{largest-double-indirect-exercise}
 Assume an inode contains 12 direct block numbers, as well as single,
 double, and triple indirect block numbers.  Further, assume that each
-block is 4~KB, and that each block number is 4 bytes.  What is the
+block is 4~KiB, and that each block number is 4 bytes.  What is the
 largest a file can be without needing to use the triple indirect block?
 \item
 Draw two alternative ``after'' pictures for Figure~\ref{B-tree-split}
@@ -2975,8 +2979,8 @@ comparison of best-fit and first-fit allocation, is by
 
 I mentioned that the analogs of inodes in Microsoft's NTFS are large
 enough to contain the entire extent maps for most files.  In the rare
-case that the extent map does not fit in a single 1-KB record, NTFS
-expands the metadata into multiple 1-KB records, but unlike other file
+case that the extent map does not fit in a single 1-KiB record, NTFS
+expands the metadata into multiple 1-KiB records, but unlike other file
 systems, it continues to use a linear extent map rather than a B$^+$-tree.
 
 B-trees were introduced by \index{Bayer, R.}Bayer and \index{McCreight, E.}McCreight~\cite{max1114}.  A

--- a/processes.tex
+++ b/processes.tex
@@ -663,8 +663,8 @@ modes.  If the kernel uses the same page table as the user-mode
 process, then the range of addresses occupied by the kernel will be
 off limits to the process.  The IA-32 architecture fits this pattern.
 For example, the Linux operating system on the IA-32 allows each
-user-mode process to access up to 3~GB of its 4-GB address space,
-while reserving 1~GB for access by the kernel only.
+user-mode process to access up to 3~GiB of its 4-GiB address space,
+while reserving 1~GiB for access by the kernel only.
 
 In this latter sort of architecture, the address space doesn't change
 when switching from a user process to a simple operating system
@@ -765,7 +765,7 @@ into several processes' address spaces.
 
 The multiple address space design is particularly appropriate on
 architectures with comparatively narrow addresses.  For example, a
-32-bit address can reference only a 4-GB address space.  If a 32-bit
+32-bit address can reference only a 4-GiB address space.  If a 32-bit
 system is going to run several processes, each of which has a couple
 gigabytes of data to access, the only way to obtain enough space is by
 using multiple address spaces.  This motivation for multiple address
@@ -2285,7 +2285,7 @@ Compare C-list capabilities with addressable capabilities.  Which is
 more powerful for the application programmer?  Which is simpler for
 the operating system designer?  Justify your answers.
 \item
-Suppose the processes on a computer occupy a total of 8~GB of virtual
+Suppose the processes on a computer occupy a total of 8~GiB of virtual
 memory, half of which is occupied by addressable capabilities.
 Suppose that each capability is represented by a random string of 256
 bits, subject to the constraint that no two of the capabilities are equal.  What is the probability that a randomly generated string of 256

--- a/synchronization.tex
+++ b/synchronization.tex
@@ -1529,9 +1529,27 @@ At this point, each of us is waiting for the other: we have
 deadlocked.
 
 More generally, a \vocab{deadlock} exists whenever there is a cycle of
-threads, each waiting for some resource held by the next.  In the
-example, there were two threads and the resources involved were two
-mutexes.  Although deadlocks can involve other resources as well
+threads, each waiting for some resource held by the next, under the
+following defining conditions:
+\begin{enumerate}\label{deadlock-conditions}
+\item Threads hold resources exclusively (``mutual exclusion'').
+\item Threads hold some resources while waiting for additional ones
+  (``wait for'').
+\item Resources cannot be removed from threads forcibly (``no
+  preemption'').
+\item Threads wait in a circular chain such that each thread holds
+  resources that are requested by the next thread in the chain.
+\end{enumerate}
+
+In the example, there are two threads and the resources involved are
+two mutexes.  Clearly, mutexes are held exclusively (condition (1)),
+each thread holds one mutex while waiting for another one (condition
+(2)), mutexes are never removed by the operating system but threads
+need to release them on their own (condition (3)), and both threads
+wait for each other, forming the shortest circular chain possible
+(condition (4)).
+
+Although deadlocks can involve other resources as well
 (consider readers/writers locks, for example), I will focus
 on mutexes for simplicity.
 
@@ -1606,7 +1624,11 @@ most practical ways to address the threat of deadlocks.
 \subsection{Deadlock Prevention Through Resource Ordering}\label{deadlock-prevention-section}
 
 The ideal way to cope with deadlocks is to prevent them from
-happening.  One very practical technique for deadlock prevention can
+happening.  In principle, deadlock prevention aims to ensure that at
+least one of the four defining conditions is not satisfied.
+One very practical technique for deadlock prevention targets the
+circular wait situation characterized by condition (4) by imposing a
+linear order in which resources need to be locked.  This technique can
 be illustrated through the example of transferring money between two bank accounts.
 Each of the two accounts is stored somewhere in the computer's
 memory, which can be specified through a numerical address.  I will
@@ -2854,8 +2876,10 @@ best of his other three approaches is ``Approach 2,'' which calls for
 obtaining all necessary resources at the same time, rather than one by
 one.  Coffman\index{Coffman, E. G.@Coffman, E.~G.}, \index{Elphick,
 M.}Elphick and \index{Shoshani, A.}Shoshani~\cite{max998} published a survey
-of deadlock issues in 1971, which made the contemporary distinction
-between deadlock prevention and deadlock avoidance.
+of deadlock issues in 1971, which is the origin of the four defining
+conditions of deadlocks presented on
+page~\pageref{deadlock-conditions} and which made the
+contemporary distinction between deadlock prevention and deadlock avoidance.
 
 In 1971, \index{Courtois, P. J.@Courtois P.~J.}Courtois,
 \index{Heymans, F.}Heymans, and \index{Parnas, D. L.@Parnas, D.~L.}Parnas~\cite{max997} described both

--- a/vm.tex
+++ b/vm.tex
@@ -782,9 +782,17 @@ beneficial.  (As explained in the notes, Linux has moved in this direction.)
 
 Typical page sizes have grown over the decades, for reasons you can
 explore in Exercises \ref{page-size-execercise-1} and \ref{page-size-execercise-2}; today, the most common
-is 4 kilobytes (KB).  Each page of virtual memory and each page frame of physical
+is 4 kibibytes (KiB).\footnote{\label{kibibyte}Sizes related to main memory are usually
+  based on powers of 2, not powers of 10 used
+  elsewhere (for example, sizes of secondary storage devices).  To
+  avoid confusion, units based on powers of 2 have been standardized
+  with their own prefixes such as ``kibi'' and ``mebi'' instead of
+  ``kilo'' and ``mega''; see the Wikipedia article on
+  {\href{https://en.wikipedia.org/wiki/Kibibyte}{Kibibytes}}
+  for more details.}
+Each page of virtual memory and each page frame of physical
 memory is this size, and each starts at an address that is a multiple
-of the page size.  For example, with 4-KB pages, the first page (or
+of the page size.  For example, with 4-KiB pages, the first page (or
 page frame) has address 0, the next has address 4096, then 8192, and
 so forth.
 
@@ -852,7 +860,7 @@ The numbers next to the
 boxes are page numbers and page frame numbers.  The starting
 addresses are these numbers multiplied by the page size.
 At the top of this figure, you can see that page~0 is stored in page
-frame~1.  If the page size is 4~KB, this means that virtual address 0
+frame~1.  If the page size is 4~KiB, this means that virtual address 0
 translates to physical address 4096, virtual address 100 translates to
 physical address 4196, and so forth.  The virtual address of the last
 4-byte word in
@@ -972,9 +980,9 @@ allocation for the rest of virtual memory.
 \item
 The operating system designers need to use tools such as variable page
 size to reduce TLB entry consumption.  At a minimum, even if all
-application processes use small pages (4~KB), the operating system
+application processes use small pages (4~KiB), the operating system
 itself can use larger pages.  Similarly, a video frame buffer of many
-consecutive megabytes needn't be carved up into 4-KB chunks.  As a
+consecutive megabytes needn't be carved up into 4-KiB chunks.  As a
 secondary benefit, using larger pages can reduce the size of page tables.
 In many cases, smaller page tables are also quicker to access.
 \item
@@ -1128,13 +1136,13 @@ information that page~3 has no valid mapping would be found 12 bytes
 after the base address of the table.
 
 The fundamental problem with linear page tables is that real ones are
-much larger than this example.  For a 32-bit address space with 4-KB
+much larger than this example.  For a 32-bit address space with 4-KiB
 pages, there are $2^{20}$ pages, because 12 of the 32 bits are used to
-specify a location within a page of 4~KB or $2^{12}$ bytes.  Thus, if
-you again assume 4~bytes per page table entry, you now have a 4-MB
+specify a location within a page of 4~KiB or $2^{12}$ bytes.  Thus, if
+you again assume 4~bytes per page table entry, you now have a 4-MiB
 page table.  Storing one of those per process could use up an
 undesirably large fraction of a computer's memory.  (My computer is currently running 70
-processes, for a hypothetical total of 280~MB of page tables, which
+processes, for a hypothetical total of 280~MiB of page tables, which
 would be 36~percent of my total RAM.) Worse yet, modern processors are moving to
 64-bit address spaces.  Even if you assume larger pages, it is hard to
 see how a linear page table spanning a 64-bit address space could be
@@ -1190,7 +1198,7 @@ valid entries, even if there are also a few invalid entries mixed in,
 and not store those chunks that contain entirely invalid entries.
 \item
 In fact, you can choose your chunks of page table to be the same size as
-the pages themselves.  For example, in a system with 4-KB pages and
+the pages themselves.  For example, in a system with 4-KiB pages and
 4-byte page table entries, each chunk of page table would contain
 1024 page table entries.  Many of these chunks won't actually need
 storage, because there are frequently 1024 unused pages in a row.  Therefore,
@@ -1320,16 +1328,16 @@ array.
 For simplicity, start by considering the two-level case.  This suffices
 for 32-bit architectures and is actually used in the extremely
 popular IA-32 architecture, the architecture of Intel's Pentium and
-AMD's Athlon family microprocessors.  The IA-32 architecture uses 4-KB
+AMD's Athlon family microprocessors.  The IA-32 architecture uses 4-KiB
 pages and has page table entries that occupy 4~bytes.  Thus, 1024
 page-table entries fit within one page-sized chunk of the page table.
-As such, a single chunk can span 4~MB of virtual address space.  Given
+As such, a single chunk can span 4~MiB of virtual address space.  Given
 that the architecture uses 32-bit virtual addresses, the full virtual address space
-is 4 gigabytes (GB) (that is, $2^{32}$ bytes); it can be spanned by 1024 chunks of the
+is 4 gibibytes (GiB) (that is, $2^{32}$ bytes); it can be spanned by 1024 chunks of the
 page table.  All you need to do is locate the storage of each of those
 1024 chunks or, in some cases, determine that the chunk didn't merit
 storage.  You can do that using a second-level structure, much like
-each of the chunks of the page table.  It, too, is 4~KB in size and
+each of the chunks of the page table.  It, too, is 4~KiB in size and
 contains 1024 entries, each of which is 4~bytes.  However, these entries in
 the second-level \vocab{page directory} point to the 1024 first-level
 chunks of the page table, rather than to individual page frames.  See
@@ -1464,19 +1472,19 @@ the memory access.
 
 This description, although somewhat simplified, shows the key
 feature of the IA-32 design: it has a compact page directory, with
-each entry covering a span of 4~MB.  For the 4-MB regions that are
+each entry covering a span of 4~MiB.  For the 4-MiB regions that are
 entirely invalid, nothing further is stored.  For the regions
 containing valid pages, the page directory entry points to another
 compact structure containing the individual page table entries.
 
 The
 actual IA-32 design derives some additional advantages from having the page
-directory entries with their 4-MB spans:
+directory entries with their 4-MiB spans:
 \begin{itemize}
 \item
 Each page directory entry can optionally point directly to a single
-large 4-MB page frame, rather than pointing to a chunk of page table
-entries leading indirectly to 4-KB page frames, as I described.  This
+large 4-MiB page frame, rather than pointing to a chunk of page table
+entries leading indirectly to 4-KiB page frames, as I described.  This
 option is controlled by a page-size bit in the page directory entry.
 By using this feature, the operating system can more efficiently
 provide the mapping information for large, contiguously allocated
@@ -1484,9 +1492,9 @@ structures.
 \item
 Each page directory entry contains permission bits, just like the page
 table entries do.  Using this feature, the operating system can mark
-an entire 4-MB region of virtual address space as being read-only
+an entire 4-MiB region of virtual address space as being read-only
 more quickly, because it doesn't need to set the read-only bits
-for each 4-KB page in the region.  The translation process
+for each 4-KiB page in the region.  The translation process
 outlined earlier is extended to check the permission bits at each
 level and signal a page fault interrupt if there is a permission
 violation at either level.
@@ -1506,12 +1514,12 @@ processors and later imitated by Intel under the name IA-32e) employs
 four-level page tables of this kind.  Although the AMD64 is nominally
 a 64-bit architecture, the virtual addresses are actually limited to
 only 48 bits in the current version of the architecture.  Because the
-basic page size is still 4~KB, the rightmost 12 bits are still the
+basic page size is still 4~KiB, the rightmost 12 bits are still the
 offset within a page.  Thus, 36 bits remain for the virtual page
 number.  Each page table entry (or similar entry at the higher levels)
 is increased in size to 8 bytes, because the physical addresses
-are larger than in IA-32.  Thus, a 4-KB chunk of page table can reference
-only 512 pages spanning 2~MB.  Similarly, the branching factor
+are larger than in IA-32.  Thus, a 4-KiB chunk of page table can reference
+only 512 pages spanning 2~MiB.  Similarly, the branching factor
 at each higher level of the tree is 512.  Because 9 bits are needed
 to select from 512 entries, it follows that the 36-bit virtual page
 number is divided into four groups of 9 bits each, one for each
@@ -1711,7 +1719,7 @@ Because segments correspond to logical objects, they serve
 as natural units for protection and sharing, as well as for
 named storage of persistent objects in files.
 However, they cannot have a
-fixed size, such as 4~KB.  Each segment will have its own natural
+fixed size, such as 4~KiB.  Each segment will have its own natural
 size.  For example, each file a process accesses might be mapped into
 the virtual address space as its own segment.  If so, the segment
 sizes will need to match the file sizes, which could be quite
@@ -2563,7 +2571,7 @@ trend in page sizes.  On the other hand, there are also real-world
 influences causing page sizes to remain unchanged for many years.  Can
 you think of what some of these influences might be?
 \item\label{page-6-translation-exercise}
-Assume a page size of 4~KB and the page mapping shown in
+Assume a page size of 4~KiB and the page mapping shown in
 Figure~\ref{example-mapping} on page~\pageref{example-mapping}.  What are the virtual addresses of the
 first and last 4-byte words in page~6?  What physical addresses do
 these translate into?
@@ -2581,7 +2589,7 @@ that for all integers $n$, page number $n$ is mapped by the page table into page
 number $f(n)$.  Give a mathematical formula for the physical address
 that corresponds with virtual address $v$.
 \item\label{linear-page-table-size-exercise}
-Suppose an architecture uses 64-bit virtual addresses and 1-MB pages.
+Suppose an architecture uses 64-bit virtual addresses and 1-MiB pages.
 Suppose that a linear page table is stored in full for each process,
 containing a page table entry for every page number.  Suppose that the size
 of each page table entry is only 4 bytes.  How large would each
@@ -2596,7 +2604,7 @@ to 32 bits.  Newer IA-32 processors offer an optional \vocab{Physical Address
 Extension} (\vocab{PAE}) mode in order to address up to sixteen times as
 much RAM.  One consequence of this is that page table entries (and
 page directory entries) are increased to 8 bytes instead of 4.
-Each page and chunk of page table is still 4~KB.
+Each page and chunk of page table is still 4~KiB.
 \begin{enumerate}
 \item
 How many entries can each chunk of page table or page directory now hold?
@@ -2604,11 +2612,11 @@ How many entries can each chunk of page table or page directory now hold?
 How big a virtual address range does each chunk of page table now
 span?  (A page directory entry can also directly point to a large
 page frame this size, just as without PAE it can directly point to a
-4-MB page frame.)
+4-MiB page frame.)
 \item
 How big a virtual address range can each page directory now span?
 \item
-Because each page directory can no longer span the full 4-GB
+Because each page directory can no longer span the full 4-GiB
 virtual address range, PAE requires adding a third level to the top of
 the tree.  The newly added root node doesn't have as large as
 branching factor as you calculated in part~(a)


### PR DESCRIPTION
I propose to use binary prefixes and units when dealing with RAM, pages, and blocks. Upon first use, I added a footnote with this link to Wikipedia: https://en.wikipedia.org/wiki/Kibibyte
I left "MB" only in the context of Fig. 6.8, where the difference between MB and MiB does not matter.