### PR TITLE
Add makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,7 @@
+all:
+	pdflatex os-book
+	bibtex os-book
+	pdflatex os-book
+	pdflatex os-book
+	makeindex os-book
+	pdflatex os-book


### PR DESCRIPTION
This is a quality-of-life improvement to allow rebuilding the text by typing `make` instead of the 6 commands specified in the readme.

This makefile runs the six commands specified in the readme to create the full-text of the book. It does not check for changes in dependencies and simply rebuilds from scratch on every invocation.